### PR TITLE
MED-74-implement-patient-list-api

### DIFF
--- a/src/common/constants/pagination-params.ts
+++ b/src/common/constants/pagination-params.ts
@@ -1,0 +1,2 @@
+export const defaultPage = 1;
+export const defaultLimit = 5;

--- a/src/modules/patients/dto/create-patient.dto.ts
+++ b/src/modules/patients/dto/create-patient.dto.ts
@@ -75,7 +75,7 @@ export class CreatePatientDto {
 
   @ApiProperty({
     description: 'Phone number of the patient',
-    example: '380991201212',
+    example: '+380991201212',
   })
   @IsString()
   @IsNotEmpty()

--- a/src/modules/patients/dto/pageOptions.dto.ts
+++ b/src/modules/patients/dto/pageOptions.dto.ts
@@ -1,22 +1,22 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { IsOptional, IsString } from 'class-validator';
+import { IsNumberString, IsOptional, IsString } from 'class-validator';
 
-export class PageOptionsDto {
+export class PatientSearchOptionsDto {
   @ApiProperty({
     description: 'Page number',
     example: 1,
   })
-  @IsString()
   @IsOptional()
-  page: number;
+  @IsNumberString()
+  page?: number;
 
   @ApiProperty({
     description: 'Quantity per page',
     example: 5,
   })
-  @IsString()
   @IsOptional()
-  limit: number;
+  @IsNumberString()
+  limit?: number;
 
   @ApiProperty({
     description: 'First/Last name to search for',
@@ -24,5 +24,5 @@ export class PageOptionsDto {
   })
   @IsString()
   @IsOptional()
-  name: string;
+  name?: string;
 }

--- a/src/modules/patients/dto/pageOptions.dto.ts
+++ b/src/modules/patients/dto/pageOptions.dto.ts
@@ -1,0 +1,28 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsOptional, IsString } from 'class-validator';
+
+export class PageOptionsDto {
+  @ApiProperty({
+    description: 'Page number',
+    example: 1,
+  })
+  @IsString()
+  @IsOptional()
+  page: number;
+
+  @ApiProperty({
+    description: 'Quantity per page',
+    example: 5,
+  })
+  @IsString()
+  @IsOptional()
+  limit: number;
+
+  @ApiProperty({
+    description: 'First/Last name to search for',
+    example: 'John',
+  })
+  @IsString()
+  @IsOptional()
+  name: string;
+}

--- a/src/modules/patients/interfaces/patients-responce.ts
+++ b/src/modules/patients/interfaces/patients-responce.ts
@@ -1,0 +1,6 @@
+import { Patient } from '@entities/Patient';
+
+export interface PatientsRes {
+  total: number;
+  patients: Patient[];
+}

--- a/src/modules/patients/patients.controller.spec.ts
+++ b/src/modules/patients/patients.controller.spec.ts
@@ -1,0 +1,51 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { HttpStatus } from '@nestjs/common';
+import { JwtService } from '@nestjs/jwt';
+import { ConfigService } from '@nestjs/config';
+import { PatientsController } from '@modules/patients/patients.controller';
+import { PatientsService } from './patients.service';
+import { PatientSearchOptionsDto } from './dto/pageOptions.dto';
+
+describe('PatientsController', () => {
+  let controller: PatientsController;
+  let service: PatientsService;
+
+  const mockAuthService = {
+    getPatients: jest.fn((x: PatientSearchOptionsDto) => {
+      return { total: 0, patients: [] };
+    }),
+    addPatient: jest.fn(() => {}),
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [PatientsController],
+      providers: [PatientsService, JwtService, ConfigService],
+    })
+      .overrideProvider(PatientsService)
+      .useValue(mockAuthService)
+      .compile();
+
+    controller = module.get<PatientsController>(PatientsController);
+    service = module.get<PatientsService>(PatientsService);
+  });
+
+  it('controller should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+
+  it('patientsService should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  it('should return result with or without parameters', async () => {
+    const dto = {
+      page: 1,
+      limit: 5,
+      name: 'Smith',
+    };
+
+    expect(await controller.getAll(dto)).toEqual({ total: 0, patients: [] });
+    expect(await controller.getAll({})).toEqual({ total: 0, patients: [] });
+  });
+});

--- a/src/modules/patients/patients.controller.spec.ts
+++ b/src/modules/patients/patients.controller.spec.ts
@@ -1,5 +1,4 @@
 import { Test, TestingModule } from '@nestjs/testing';
-import { HttpStatus } from '@nestjs/common';
 import { JwtService } from '@nestjs/jwt';
 import { ConfigService } from '@nestjs/config';
 import { PatientsController } from '@modules/patients/patients.controller';
@@ -8,11 +7,10 @@ import { PatientSearchOptionsDto } from '@modules/patients/dto/pageOptions.dto';
 
 describe('PatientsController', () => {
   let controller: PatientsController;
-  let service: PatientsService;
 
   const mockAuthService = {
     getPatients: jest.fn((x: PatientSearchOptionsDto) => {
-      return { total: 0, patients: [] };
+      return x;
     }),
     addPatient: jest.fn(() => {}),
   };
@@ -27,7 +25,6 @@ describe('PatientsController', () => {
       .compile();
 
     controller = module.get<PatientsController>(PatientsController);
-    service = module.get<PatientsService>(PatientsService);
   });
 
   it('should return result with or without parameters', async () => {
@@ -37,7 +34,7 @@ describe('PatientsController', () => {
       name: 'Smith',
     };
 
-    expect(await controller.getAll(dto)).toEqual({ total: 0, patients: [] });
-    expect(await controller.getAll({})).toEqual({ total: 0, patients: [] });
+    expect(await controller.getAll(dto)).toEqual(dto);
+    expect(await controller.getAll({})).toEqual({});
   });
 });

--- a/src/modules/patients/patients.controller.spec.ts
+++ b/src/modules/patients/patients.controller.spec.ts
@@ -30,14 +30,6 @@ describe('PatientsController', () => {
     service = module.get<PatientsService>(PatientsService);
   });
 
-  it('controller should be defined', () => {
-    expect(controller).toBeDefined();
-  });
-
-  it('patientsService should be defined', () => {
-    expect(service).toBeDefined();
-  });
-
   it('should return result with or without parameters', async () => {
     const dto = {
       page: 1,

--- a/src/modules/patients/patients.controller.spec.ts
+++ b/src/modules/patients/patients.controller.spec.ts
@@ -3,8 +3,8 @@ import { HttpStatus } from '@nestjs/common';
 import { JwtService } from '@nestjs/jwt';
 import { ConfigService } from '@nestjs/config';
 import { PatientsController } from '@modules/patients/patients.controller';
-import { PatientsService } from './patients.service';
-import { PatientSearchOptionsDto } from './dto/pageOptions.dto';
+import { PatientsService } from '@modules/patients/patients.service';
+import { PatientSearchOptionsDto } from '@modules/patients/dto/pageOptions.dto';
 
 describe('PatientsController', () => {
   let controller: PatientsController;

--- a/src/modules/patients/patients.controller.ts
+++ b/src/modules/patients/patients.controller.ts
@@ -13,9 +13,9 @@ import { IServerResponse } from '@common/interfaces/serverResponses';
 import { CreatePatientDto } from '@modules/patients/dto/create-patient.dto';
 import { Patient } from '@entities/Patient';
 import { AuthGuard } from '@nestjs/passport';
-import { PatientsService } from './patients.service';
-import { PatientSearchOptionsDto } from './dto/pageOptions.dto';
-import { PatientsRes } from './interfaces/patients-responce';
+import { PatientsService } from '@modules/patients/patients.service';
+import { PatientSearchOptionsDto } from '@modules/patients/dto/pageOptions.dto';
+import { PatientsRes } from '@modules/patients/interfaces/patients-responce';
 
 @ApiTags('patients')
 @Controller('patients')

--- a/src/modules/patients/patients.controller.ts
+++ b/src/modules/patients/patients.controller.ts
@@ -14,7 +14,7 @@ import { CreatePatientDto } from '@modules/patients/dto/create-patient.dto';
 import { Patient } from '@entities/Patient';
 import { AuthGuard } from '@nestjs/passport';
 import { PatientsService } from './patients.service';
-import { PageOptionsDto } from './dto/pageOptions.dto';
+import { PatientSearchOptionsDto } from './dto/pageOptions.dto';
 import { PatientsRes } from './interfaces/patients-responce';
 
 @ApiTags('patients')
@@ -42,7 +42,9 @@ export class PatientsController {
     status: 201,
     description: 'List of all possible specialities',
   })
-  async getAll(@Query() searchOptions: PageOptionsDto): Promise<PatientsRes> {
+  async getAll(
+    @Query() searchOptions: PatientSearchOptionsDto,
+  ): Promise<PatientsRes> {
     const response = await this.patientsService.getPatients(searchOptions);
     if (!response) throw new NotFoundException('There are no patients!');
     return response;

--- a/src/modules/patients/patients.controller.ts
+++ b/src/modules/patients/patients.controller.ts
@@ -1,12 +1,25 @@
-import { Body, Controller, HttpStatus, Post, UseGuards } from '@nestjs/common';
-import { ApiOperation, ApiResponse } from '@nestjs/swagger';
+import {
+  Body,
+  Controller,
+  Get,
+  HttpStatus,
+  NotFoundException,
+  Post,
+  Query,
+  UseGuards,
+} from '@nestjs/common';
+import { ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
 import { IServerResponse } from '@common/interfaces/serverResponses';
 import { CreatePatientDto } from '@modules/patients/dto/create-patient.dto';
 import { Patient } from '@entities/Patient';
 import { AuthGuard } from '@nestjs/passport';
 import { PatientsService } from './patients.service';
+import { PageOptionsDto } from './dto/pageOptions.dto';
+import { PatientsRes } from './interfaces/patients-responce';
 
+@ApiTags('patients')
 @Controller('patients')
+@UseGuards(AuthGuard('jwt'))
 export class PatientsController {
   constructor(private readonly patientsService: PatientsService) {}
 
@@ -16,11 +29,22 @@ export class PatientsController {
     status: 201,
     description: 'Patient was created',
   })
-  @UseGuards(AuthGuard('jwt'))
   async addPatient(
     @Body() dto: CreatePatientDto,
   ): Promise<IServerResponse<Patient>> {
     const patient = await this.patientsService.addPatient(dto);
     return { statusCode: HttpStatus.OK, data: patient };
+  }
+
+  @Get()
+  @ApiOperation({ summary: 'Get latest patients' })
+  @ApiResponse({
+    status: 201,
+    description: 'List of all possible specialities',
+  })
+  async getAll(@Query() searchOptions: PageOptionsDto): Promise<PatientsRes> {
+    const response = await this.patientsService.getPatients(searchOptions);
+    if (!response) throw new NotFoundException('There are no patients!');
+    return response;
   }
 }

--- a/src/modules/patients/patients.controller.ts
+++ b/src/modules/patients/patients.controller.ts
@@ -40,7 +40,7 @@ export class PatientsController {
   @ApiOperation({ summary: 'Get latest patients' })
   @ApiResponse({
     status: 201,
-    description: 'List of all possible specialities',
+    description: 'Get latest patients or search by name',
   })
   async getAll(
     @Query() searchOptions: PatientSearchOptionsDto,

--- a/src/modules/patients/patients.service.spec.ts
+++ b/src/modules/patients/patients.service.spec.ts
@@ -6,7 +6,7 @@ import { PatientsService } from './patients.service';
 
 describe('PatientsService', () => {
   let service: PatientsService;
-  let mockRepository = Repository<Patient>;
+  // let mockRepository = Repository<Patient>;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
@@ -20,7 +20,7 @@ describe('PatientsService', () => {
     }).compile();
 
     service = module.get<PatientsService>(PatientsService);
-    mockRepository = module.get(getRepositoryToken(Patient));
+    // mockRepository = module.get(getRepositoryToken(Patient));
   });
 
   it('should be defined', () => {

--- a/src/modules/patients/patients.service.spec.ts
+++ b/src/modules/patients/patients.service.spec.ts
@@ -1,0 +1,29 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { Patient } from '@entities/Patient';
+import { PatientsService } from './patients.service';
+
+describe('PatientsService', () => {
+  let service: PatientsService;
+  let mockRepository = Repository<Patient>;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        PatientsService,
+        {
+          provide: getRepositoryToken(Patient),
+          useClass: Repository,
+        },
+      ],
+    }).compile();
+
+    service = module.get<PatientsService>(PatientsService);
+    mockRepository = module.get(getRepositoryToken(Patient));
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/src/modules/patients/patients.service.ts
+++ b/src/modules/patients/patients.service.ts
@@ -3,8 +3,8 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { Injectable } from '@nestjs/common';
 import { CreatePatientDto } from '@modules/patients/dto/create-patient.dto';
 import { Patient } from '@entities/Patient';
-import { PatientSearchOptionsDto } from './dto/pageOptions.dto';
-import { PatientsRes } from './interfaces/patients-responce';
+import { PatientSearchOptionsDto } from '@modules/patients/dto/pageOptions.dto';
+import { PatientsRes } from '@modules/patients/interfaces/patients-responce';
 
 @Injectable()
 export class PatientsService {

--- a/src/modules/patients/patients.service.ts
+++ b/src/modules/patients/patients.service.ts
@@ -3,7 +3,7 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { Injectable } from '@nestjs/common';
 import { CreatePatientDto } from '@modules/patients/dto/create-patient.dto';
 import { Patient } from '@entities/Patient';
-import { PageOptionsDto } from './dto/pageOptions.dto';
+import { PatientSearchOptionsDto } from './dto/pageOptions.dto';
 import { PatientsRes } from './interfaces/patients-responce';
 
 @Injectable()
@@ -14,7 +14,7 @@ export class PatientsService {
     return this.repo.save(dto);
   }
 
-  async getPatients(query: PageOptionsDto): Promise<PatientsRes> {
+  async getPatients(query: PatientSearchOptionsDto): Promise<PatientsRes> {
     const queryBuilder = this.repo.createQueryBuilder('patient');
     const { name } = query;
     const limit = query.limit || 5;

--- a/src/modules/patients/patients.service.ts
+++ b/src/modules/patients/patients.service.ts
@@ -3,6 +3,8 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { Injectable } from '@nestjs/common';
 import { CreatePatientDto } from '@modules/patients/dto/create-patient.dto';
 import { Patient } from '@entities/Patient';
+import { PageOptionsDto } from './dto/pageOptions.dto';
+import { PatientsRes } from './interfaces/patients-responce';
 
 @Injectable()
 export class PatientsService {
@@ -10,5 +12,37 @@ export class PatientsService {
 
   addPatient(dto: CreatePatientDto): Promise<Patient> {
     return this.repo.save(dto);
+  }
+
+  async getPatients(query: PageOptionsDto): Promise<PatientsRes> {
+    const queryBuilder = this.repo.createQueryBuilder('patient');
+    const { name } = query;
+    const limit = query.limit || 5;
+    const page = query.page || 1;
+    const skip = (page - 1) * limit;
+
+    if (name) {
+      const total = await queryBuilder.getCount();
+      const patients = await queryBuilder
+        .take(limit)
+        .skip(skip)
+        .where('last_name like :lastName', { lastName: `%${name}%` })
+        .orWhere('first_name like :firstName', {
+          firstName: `%${name}%`,
+        })
+        .orderBy('patient.updatedAt', 'DESC')
+        .getMany();
+
+      return { total, patients };
+    }
+
+    const total = await queryBuilder.getCount();
+    const patients = await queryBuilder
+      .take(limit)
+      .skip(skip)
+      .orderBy('patient.updatedAt', 'DESC')
+      .getMany();
+
+    return { total, patients };
   }
 }

--- a/src/modules/patients/patients.service.ts
+++ b/src/modules/patients/patients.service.ts
@@ -5,6 +5,7 @@ import { CreatePatientDto } from '@modules/patients/dto/create-patient.dto';
 import { Patient } from '@entities/Patient';
 import { PatientSearchOptionsDto } from '@modules/patients/dto/pageOptions.dto';
 import { PatientsRes } from '@modules/patients/interfaces/patients-responce';
+import { defaultLimit, defaultPage } from '@common/constants/pagination-params';
 
 @Injectable()
 export class PatientsService {
@@ -17,8 +18,8 @@ export class PatientsService {
   async getPatients(query: PatientSearchOptionsDto): Promise<PatientsRes> {
     const queryBuilder = this.repo.createQueryBuilder('patient');
     const { name } = query;
-    const limit = query.limit || 5;
-    const page = query.page || 1;
+    const limit = query.limit || defaultLimit;
+    const page = query.page || defaultPage;
     const skip = (page - 1) * limit;
 
     if (name) {


### PR DESCRIPTION
**Patients list API:**

- Added route to get latest patients or to search by name
- Added pagination for this route

1.2 Backend

- [x] 1.2.1 swagger for each endpoint. add in the documentation, different types of responses.
 on a successful response (2xx), on unsuccessful response (4xx, 5xx)

- [x] 1.2.2 less requests to db, all data should be taken with one query
- [x] 1.2.3 `public` in method use only is use function externally
- [x] 1.2.4 use ConfigService instead of `process.env`
- [x] 1.2.5 use @`@index` decorator  for frequently requested data
- [x] 1.2.6 use transactions if there is a call chain that mutates data in different tables
- [x] 1.2.7. add a set of rules for [[nestjs](https://github.com/darraghoriordan/eslint-plugin-nestjs-typed)](https://github.com/darraghoriordan/eslint-plugin-nestjs-typed) to the .eslint config file. It helps to prevent bugs and confusing moments

**Without parameters returning 1 page of latest updated patients**
![image](https://user-images.githubusercontent.com/102911058/234885430-b5330298-7d11-4066-98ed-6a6bcc06659b.png)

**Pagination parameters** 
![image](https://user-images.githubusercontent.com/102911058/234886240-8ce9850a-4516-4986-a361-e897d0de52d5.png)

**With "name" parameter returns one page of patients, that were found by query in first name/last name**
![image](https://user-images.githubusercontent.com/102911058/234885675-473047f8-9a49-4ebd-86cf-1321a566dd58.png)
